### PR TITLE
Port over to ZMQ::LibZMQ2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,7 +60,7 @@ WriteMakefile(
     'YAML' => 0,
     'Statistics::Descriptive' => 0,
     'Term::ProgressBar' => 0,
-    'ZeroMQ' => 0,
+    'ZMQ::LibZMQ2' => 0,
     'Mojolicious' => 0,
     'File::ShareDir' => 0,
     'File::Share' => 0,

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends-Indep:
  liblist-compare-perl,
  libstatistics-descriptive-perl,
  libyaml-perl,
- libzeromq-perl,
+ libzmq-libzmq2-perl,
  libfile-sharedir-install-perl,
  libfile-sharedir-perl,
  libfile-share-perl,


### PR DESCRIPTION
Hello, this is a port fom `ZeroMQ` (deprecated) to its replacement `ZMQ::LibZMQ2`. `ZMQ::LibZMQ2` is a little "lower level", so instead of a OO API we have a procedural one that looks very much like the ZMQ C API (but which is still very similar).

It works, and IMO is ready. But I would like comments anyway.

Before merging there is one problem we have to face: ZMQ::LibZMQ2 is on Debian unstable, but not on wheezy (let alone squeeze), and is not in any Ubuntu release. Supporting all those different systems is starting to require quite some effort ...
