### PR TITLE
Module yaml2csv working properly with tests

### DIFF
--- a/lib/Analizo/Batch/Output/CSV.pm
+++ b/lib/Analizo/Batch/Output/CSV.pm
@@ -2,6 +2,8 @@ package Analizo::Batch::Output::CSV;
 
 use base qw( Analizo::Batch::Output );
 use Analizo::Metrics;
+use YAML;
+use Analizo::Batch::Output::yaml2csv;
 
 sub push {
   my ($self, $job) = @_;
@@ -31,6 +33,15 @@ sub write_data {
     my @values = map { _encode_value($summary->{$_}) } @fields;
     my $line = join(',', $job->id, @metadata, @values) . "\n";
     print $fh $line;
+
+    #print "Writing details file for ... ",  $job->directory, "\n";
+    my $details_yaml = $job->directory . "-details.yml";
+    open DETAILS, '>' . $details_yaml;
+    print DETAILS join('', map { Dump($_)} @$details);
+    close DETAILS;
+
+    my $yaml2csv = Analizo::Batch::Output::yaml2csv->new($job->directory);
+    $yaml2csv->write_csv();
   }
 }
 

--- a/lib/Analizo/Batch/Output/yaml2csv.pm
+++ b/lib/Analizo/Batch/Output/yaml2csv.pm
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+package Analizo::Batch::Output::yaml2csv;
+
+sub new 
+{
+  my ($class, @yaml_file) = @_;
+  return bless {job_directory => @yaml_file}, $class;
+}
+
+sub extract_labels
+{
+  my ($self) = @_;
+  my @labels = ();
+
+  open(my $yaml_handler, "<", $self->{job_directory} . "-details.yml")  || return 0;
+
+  while(!eof $yaml_handler)
+  { 
+    my $line = readline $yaml_handler;
+    if($line ne "---\n" and $line =~ m/(\w+):/)
+    {
+      push @labels, $1;
+      if($1 eq "sc")
+      {
+        close $yaml_handler;
+        last;
+      }
+    }
+  }
+    
+  return @labels;
+}
+
+
+sub extract_lines
+{
+  my ($self, $number_of_labels) = @_;
+  my @values = ();
+  my @array_of_values = ();
+  my @files_names = ();
+
+  open(my $yaml_handler, "<", $self->{job_directory} . "-details.yml")  || return 0;  
+  
+  while(my $line = readline $yaml_handler)
+  {
+    if($line =~ m/( .*)/)
+    {
+      if($1 =~ m/(- (.*))/ )
+      {
+        push @files_names, $1." ";
+      }
+      else
+      {
+        push @values, $1;  
+      }
+      if($number_of_labels == ((@values)+1))
+      { 
+        push @array_of_values, @files_names;
+        push @array_of_values, ",";
+        push @array_of_values, join(",", @values);
+        push @array_of_values, "\n";
+        @values = ();
+        @files_names = ();
+      }
+    }
+  } 
+  close $yaml_handler;
+  return @array_of_values;
+}
+
+sub write_csv 
+{
+  my ($self) = @_;
+  my $csv_filename = $self->{job_directory} . "-details.csv";
+  
+  open my $csv_handler, '>'.$csv_filename  || die "Cannot open ".$self->{job_directory} . "-details.csv\n".$!;
+
+  my $number_of_labels = $self->extract_labels();
+  print $csv_handler join(",", $self->extract_labels());
+  print $csv_handler "\n";
+
+  my @array_of_values =  $self->extract_lines($number_of_labels);
+  foreach(@array_of_values)
+  {
+     print $csv_handler $_;  
+  }
+
+  close $csv_handler;
+}
+
+1;

--- a/t/Analizo/Batch/Output/CSV.t
+++ b/t/Analizo/Batch/Output/CSV.t
@@ -6,6 +6,7 @@ use Test::More 'no_plan';
 use t::Analizo::Test;
 
 use Analizo::Batch::Output::CSV;
+use Analizo::Batch::Output::yaml2csv;
 use Analizo::Batch::Job::Directories;
 
 my $TMPDIR = tmpdir();

--- a/t/Analizo/Batch/Output/yaml2csv.t
+++ b/t/Analizo/Batch/Output/yaml2csv.t
@@ -1,0 +1,98 @@
+package t::Analizo::Batch::Output::CSV;
+use strict;
+use warnings;
+use base qw(t::Analizo::Test::Class);
+use Test::More 'no_plan';
+use t::Analizo::Test;
+
+use Analizo::Batch::Output::CSV;
+use Analizo::Batch::Output::yaml2csv;
+use Analizo::Batch::Job::Directories;
+
+my $TMPDIR = tmpdir();
+my $TMPFILE = "$TMPDIR/output.csv";
+
+sub setup : Tests(setup) {
+  system("mkdir -p $TMPDIR");
+  my $output = __create();
+
+  my $job1 = new Analizo::Batch::Job::Directories('t/samples/animals/cpp');
+  $job1->execute();
+  $output->push($job1);
+
+  my $job2 = new Analizo::Batch::Job::Directories('t/samples/animals/java');
+  $job2->execute();
+  $output->push($job2);
+
+  $output->file($TMPFILE);
+  $output->flush();
+
+  my @lines = readfile $TMPFILE;
+}
+
+sub teardown : Tests(teardown) {
+  system("rm -rf $TMPDIR");
+}
+
+sub constructor : Tests {
+  my $output = __create();
+  isa_ok($output, 'Analizo::Batch::Output::CSV');
+
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("../../../samples/animals/java"); 
+  isnt($yaml2csv, undef);
+  can_ok($yaml2csv, 'extract_lines');
+  can_ok($yaml2csv, 'extract_labels');
+  can_ok($yaml2csv, 'write_csv');
+}
+
+sub extract_labels : Tests {
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("t/samples/animals/java"); 
+  isnt($yaml2csv, undef);
+  is($yaml2csv->extract_labels(),18); 
+  my @labels = $yaml2csv->extract_labels();
+  is($labels[0],"_filename"); 
+  is($labels[17],"sc");   
+}
+
+sub extract_lines_cpp : Tests {
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("t/samples/animals/cpp"); 
+  isnt($yaml2csv, undef);
+  my @array_of_values = $yaml2csv->extract_lines(extract_labels());
+  isnt(@array_of_values, undef);
+  is($array_of_values[0], '- animal.h ');    
+}
+
+sub extract_lines_java : Tests {
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("t/samples/animals/java"); 
+  isnt($yaml2csv, undef);
+  my @array_of_values = $yaml2csv->extract_lines(extract_labels());
+  isnt(@array_of_values, undef);
+  is($array_of_values[0], '- Animal.java ');    
+} 
+
+sub write_csv_cpp : Tests {
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("t/samples/animals/cpp"); 
+  $yaml2csv->write_csv(); 
+  isnt($yaml2csv, undef);  
+  open(my $file_cpp, "<", $yaml2csv->{job_directory} . "-details.csv") || die "Cannot open ".$yaml2csv->{job_directory} . "-details.csv\n".$!;
+  is(-e $file_cpp, 1);
+}
+
+
+sub write_csv_java : Tests {
+  my $yaml2csv = Analizo::Batch::Output::yaml2csv->new("t/samples/animals/java");
+  $yaml2csv->write_csv(); 
+  isnt($yaml2csv, undef);  
+  open(my $file_java, "<", $yaml2csv->{job_directory} . "-details.csv") || die "Cannot open ".$yaml2csv->{job_directory} . "-details.csv\n".$!;
+  is(-e $file_java, 1);
+}
+
+sub __create {
+  my @args = @_;
+  return new Analizo::Batch::Output::CSV(@args);
+}
+
+
+__PACKAGE__->runtests;
+
+1;


### PR DESCRIPTION
Pull request to solve Issue 19: https://github.com/analizo/analizo/issues/19

The yaml2csv module extract data from YAML files to write the xxx-details.csv per project containing the module-level metrics for that project.
