### PR TITLE
Fixes keys on reference for ClangStaticAnalyzer

### DIFF
--- a/lib/Analizo/Extractor/ClangStaticAnalyzer.pm
+++ b/lib/Analizo/Extractor/ClangStaticAnalyzer.pm
@@ -120,7 +120,7 @@ sub feed {
 
     $self->model->declare_module($module, $file_name);
 
-    foreach $bug (keys $bugs_hash) {
+    foreach $bug (keys %$bugs_hash) {
       my $value = $tree->{$file_name}->{$bug};
       $self->model->declare_security_metrics($bug, $module, $value);
     }


### PR DESCRIPTION
Perl 5.20 returns the following warning on all Analizo's commands on terminal:

`keys on reference is experimental at /usr/share/perl5/site_perl/Analizo/Extractor/ClangStaticAnalyzer.pm line 123, <DATA> line 1.`

So I dereferenced the var according to http://www.tutorialspoint.com/perl/perl_references.htm. I'm not a Perl programmer so I'm sorry if this is completly wrong :)
