### PR TITLE
Fixing the security metrics acceptance test

### DIFF
--- a/lib/Analizo/Batch/Job.pm
+++ b/lib/Analizo/Batch/Job.pm
@@ -129,8 +129,11 @@ sub execute {
   my $model = $self->cache->get($model_cache_key);
   if (!defined $model) {
     $model = new Analizo::Model;
+
+    my @options_array =  ($self->includedirs, $self->libdirs, $self->libs, "model", $model);
+
     my @extractors = (
-      Analizo::Extractor->load($self->extractor, model => $model),
+      Analizo::Extractor->load($self->extractor, @options_array),
       new Analizo::Extractor::Sloccount(model => $model),
     );
     for my $extractor (@extractors) {

--- a/lib/Analizo/Extractor.pm
+++ b/lib/Analizo/Extractor.pm
@@ -45,8 +45,15 @@ sub load {
   eval "use $extractor";
   die "error loading $extractor_method extractor: $@" if $@;
 
-  eval { $extractor = $extractor->new(@options) };
-  die "error instancing extractor: $@" if $@;
+  if($extractor_method ne "ClangStaticAnalyzer" && scalar @options > 2){
+         my ($includedirs, $libdirs, $libs,@options_array) = @options;
+         eval { $extractor = $extractor->new(@options_array) };
+         die "error instancing extractor: $@" if $@;
+  }
+  else {
+       eval { $extractor = $extractor->new(@options) };
+       die "error instancing extractor: $@" if $@;
+   }   
 
   return $extractor;
 }


### PR DESCRIPTION
This closes #66 and Analizo-UnB/analizo#34 by changing the way the Extractor::load
instatiated the ClangStaticAnalyzer extractor and also changing the Batch::Job::execute
method to pass the necessary parameters to the Extractor::load method

Signed-off-by: Lucas Moura lucas.moura128@gmail.com
Signed-off-by: Arthur Jahn stutrzbecher@gmail.com
