### PR TITLE
Fixing running of a single acceptance test

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -16,10 +16,20 @@ use t::Analizo::Test::BDD::Cucumber::Harness;
 # The features are returned in @features, and the executor is created with the
 # step definitions loaded.
 # It's possible to execute just a feature by passing it as argument in
-# command-line. Like: $ perl test.pl t/features/dsm.feature
-my ($executor, @features) = @ARGV == 0
-  ? Test::BDD::Cucumber::Loader->load('t/features/')
-  : Test::BDD::Cucumber::Loader->load(@ARGV);
+# command-line. Like: $ perl -I. test.pl t/features/dsm.feature
+
+my ($executor, @features);
+
+if(@ARGV == 0) {
+  ($executor, @features) = Test::BDD::Cucumber::Loader->load('t/features/');
+} else {
+  ($executor, @features) = Test::BDD::Cucumber::Loader->load(@ARGV);
+
+  my $number_of_steps = keys %{$executor->{steps}};
+  if($number_of_steps == 0){
+    Test::BDD::Cucumber::Loader->load_steps($executor, 't/features/step_definitions/');
+  }
+}
 
 # Create a Harness to execute against. TestBuilder harness prints TAP
 my $harness = t::Analizo::Test::BDD::Cucumber::Harness->new({});


### PR DESCRIPTION
Cucumber wasn't running a single acceptance test under t/features/metrics/
because it's impossible to load step definitions from a path out of the
directory where the *.feature file is loaded.

The strategy to solve this problem is to count the number of steps loaded
after calling Cucumber load method. If the Hash of steps is empty, it calls
the method load_steps through the t/features/step_definitions folder.

Now it is possible to load steps when calling sigle tests from any folder.

Closes issue #71 

Signed-off-by: Luan Guimarães <livreluan@gmail.com>
Signed-off-by: Izabela Cardoso <cizabelacristina@gmail.com>