### PR TITLE
Configuring previous version of Ubuntu Trusty @ .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+group: deprecated-2017Q2
+
 language: perl
 
 services: docker


### PR DESCRIPTION
Travis has changed the version of Ubuntu Trusty causing an unexpected behavior while Docker user tries to write inside container. This merge inserts a flag at .travis.yml to tell Travis to use the previous version of Trusty.