### PR TITLE
Creating Test for Java Enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.20.8] - 2018-03-23
+
+### Added
+- Auto generate META.json using dzil plugin MetaJSON
+
+### Fixed
+- Changed markdown syntax to fix pandoc html transforming
+- Tests depends on File::Slurp
+- Env::Path is required at runtime
+
+### Removed
+- Removed dependency for Method::Signatures
+
 ## [1.20.7] - 2018-02-07
 
 ### Changed
@@ -106,3 +119,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.20.5]: https://github.com/analizo/analizo/compare/1.20.4...1.20.5
 [1.20.6]: https://github.com/analizo/analizo/compare/1.20.5...1.20.6
 [1.20.7]: https://github.com/analizo/analizo/compare/1.20.6...1.20.7
+[1.20.8]: https://github.com/analizo/analizo/compare/1.20.7...1.20.8

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+analizo (1.20.8) unstable; urgency=medium
+
+  * removing dependency for Method::Signatures
+  * Env::Path is required at runtime #115 (thanks @rafamanzo @eserte)
+  * auto generate META.json using dzil plugin [MetaJSON]  (thanks @manwar)
+  * tests depends on File::Slurp #114
+  * change markdown syntax to avoid error transforming doc in html
+
+ -- Joenio Costa <joenio@joenio.me>  Fri, 23 Mar 2018 15:49:45 -0300
+
 analizo (1.20.7) unstable; urgency=medium
 
   * Change development script to install CPAN modules without sudo

--- a/t/features/enumeration.feature
+++ b/t/features/enumeration.feature
@@ -1,0 +1,15 @@
+Feature: analizing projects with enumerations
+  As a software developer
+  I want analizo to correctly analize projects with enumerations
+  So that I can evaluate it
+
+  Scenario: "Enumeration" project modules
+    Given I am in t/samples/enumeration/<language>
+    When I run "analizo metrics ."
+    Then analizo must report that the project has total_modules = <total_modules>
+    And analizo must report that file Enumeration.java declares module Enumeration
+    And analizo must report that file Main.java declares module Main::MyEnumeration
+    Examples:
+      | language | total_modules |
+      | java     | 3             |
+

--- a/t/features/enumeration.feature
+++ b/t/features/enumeration.feature
@@ -13,3 +13,11 @@ Feature: analizing projects with enumerations
       | language | total_modules |
       | java     | 3             |
 
+  Scenario: "Enumeration" project metrics
+    Given I am in t/samples/enumeration/<language>
+    When I run "analizo metrics ."  
+    Then analizo must report that the module <main_enum_module> has noa = 4
+    And analizo must report that the module <enum_module> has noa = 4
+    Examples:
+      | language | main_enum_module        | enum_module |
+      | java     | Main::MyEnumeration     | Enumeration |

--- a/t/features/enumeration.feature
+++ b/t/features/enumeration.feature
@@ -24,16 +24,11 @@ Feature: analizing projects with enumerations
   Scenario: "Enumeration" module metrics
     Given I am in t/samples/enumeration/<language>
     When I run "analizo metrics ."
-    Then analizo must report that the module <module> has <metric> = <value>
+    Then analizo must report that module <module> has <metric> = <value>
     Examples:
       | language | module              | metric | value |
-      | java     | Main                | accm   | 2     |
-      | java     | Main                | amloc  | 8     |
-      | java     | Main                | anpm   | 1     |
-      | java     | Main                | cbo    | 1     |
-      | java     | Main                | lcom4  | 1     |
       | java     | Main                | loc    | 8     |
-      | java     | Main                | mmloc  | '8'   |
+      | java     | Main                | mmloc  | 8     |
       | java     | Main                | nom    | 1     |
       | java     | Main                | npm    | 1     |
       | java     | Main                | rfc    | 2     |

--- a/t/features/enumeration.feature
+++ b/t/features/enumeration.feature
@@ -7,8 +7,6 @@ Feature: analizing projects with enumerations
     Given I am in t/samples/enumeration/<language>
     When I run "analizo metrics ."
     Then analizo must report that the project has total_modules = <total_modules>
-    And analizo must report that file Enumeration.java declares module Enumeration
-    And analizo must report that file Main.java declares module Main::MyEnumeration
     Examples:
       | language | total_modules |
       | java     | 3             |
@@ -16,46 +14,32 @@ Feature: analizing projects with enumerations
   Scenario: "Enumeration" project modules names
     Given I am in t/samples/enumeration/<language>
     When I run "analizo metrics ."
-    Then analizo must report that file <filename> declares module <wildcard_class>
-      | language | filename           | enumeration_modules  |
-      | java     | Main.java          | Main                 |
-      | java     | Main.java          | Main::MyEnumeration  |
-      | java     | Enumeration.java   | Enumeration          |
+    Then analizo must report that file <filename> declares module <enumeration_modules>
+    Examples:
+      | language | filename         | enumeration_modules |
+      | java     | Main.java        | Main                |
+      | java     | Main.java        | Main::MyEnumeration |
+      | java     | Enumeration.java | Enumeration         |
 
-  Scenario: "Enumeration" project, Main module metrics
+  Scenario: "Enumeration" module metrics
     Given I am in t/samples/enumeration/<language>
     When I run "analizo metrics ."
-    Then analizo must report that the module <main_module> has accm = 0
-    And analizo must report that the module <main_module> has accm = 2
-    And analizo must report that the module <main_module> has amloc = 8
-    And analizo must report that the module <main_module> has anpm = 1
-    And analizo must report that the module <main_module> has cbo = 1
-    And analizo must report that the module <main_module> has lcom4 = 1
-    And analizo must report that the module <main_module> has loc = 8
-    And analizo must report that the module <main_module> has mmloc = '8'
-    And analizo must report that the module <main_module> has nom = 1
-    And analizo must report that the module <main_module> has npm = 1
-    And analizo must report that the module <main_module> has rfc = 2
-    And analizo must report that the module <main_module> has sc = 1
+    Then analizo must report that the module <module> has <metric> = <value>
     Examples:
-      | language | main_module |
-      | java     | Main        |
-
-  Scenario: "Enumeration" project, Main::MyEnumeration module metrics
-    Given I am in t/samples/enumeration/<language>
-    When I run "analizo metrics ."
-    Then analizo must report that the module <main_enum_module> has acc = 1
-    And analizo must report that the module <main_enum_module> has noa = 4
-    And analizo must report that the module <main_enum_module> has npa = 4
-    Examples:
-      | language | main_enum_module    |
-      | java     | Main::MyEnumeration |
-
-  Scenario: "Enumeration" project, Enumeration module metrics
-    Given I am in t/samples/enumeration/<language>
-    When I run "analizo metrics ."
-    And analizo must report that the module <enum_module> has noa = 4
-    And analizo must report that the module <enum_module> has npa = 4
-    Examples:
-      | language | enum_module |
-      | java     | Enumeration |
+      | language | module              | metric | value |
+      | java     | Main                | accm   | 2     |
+      | java     | Main                | amloc  | 8     |
+      | java     | Main                | anpm   | 1     |
+      | java     | Main                | cbo    | 1     |
+      | java     | Main                | lcom4  | 1     |
+      | java     | Main                | loc    | 8     |
+      | java     | Main                | mmloc  | '8'   |
+      | java     | Main                | nom    | 1     |
+      | java     | Main                | npm    | 1     |
+      | java     | Main                | rfc    | 2     |
+      | java     | Main                | sc     | 1     |
+      | java     | Main::MyEnumeration | acc    | 1     |
+      | java     | Main::MyEnumeration | noa    | 4     |
+      | java     | Main::MyEnumeration | npa    | 4     |
+      | java     | Enumeration         | noa    | 4     |
+      | java     | Enumeration         | npa    | 4     |

--- a/t/features/enumeration.feature
+++ b/t/features/enumeration.feature
@@ -3,7 +3,7 @@ Feature: analizing projects with enumerations
   I want analizo to correctly analize projects with enumerations
   So that I can evaluate it
 
-  Scenario: "Enumeration" project modules
+  Scenario: "Enumeration" project modules count
     Given I am in t/samples/enumeration/<language>
     When I run "analizo metrics ."
     Then analizo must report that the project has total_modules = <total_modules>
@@ -13,11 +13,49 @@ Feature: analizing projects with enumerations
       | language | total_modules |
       | java     | 3             |
 
-  Scenario: "Enumeration" project metrics
+  Scenario: "Enumeration" project modules names
     Given I am in t/samples/enumeration/<language>
-    When I run "analizo metrics ."  
-    Then analizo must report that the module <main_enum_module> has noa = 4
-    And analizo must report that the module <enum_module> has noa = 4
+    When I run "analizo metrics ."
+    Then analizo must report that file <filename> declares module <wildcard_class>
+      | language | filename           | enumeration_modules  |
+      | java     | Main.java          | Main                 |
+      | java     | Main.java          | Main::MyEnumeration  |
+      | java     | Enumeration.java   | Enumeration          |
+
+  Scenario: "Enumeration" project, Main module metrics
+    Given I am in t/samples/enumeration/<language>
+    When I run "analizo metrics ."
+    Then analizo must report that the module <main_module> has accm = 0
+    And analizo must report that the module <main_module> has accm = 2
+    And analizo must report that the module <main_module> has amloc = 8
+    And analizo must report that the module <main_module> has anpm = 1
+    And analizo must report that the module <main_module> has cbo = 1
+    And analizo must report that the module <main_module> has lcom4 = 1
+    And analizo must report that the module <main_module> has loc = 8
+    And analizo must report that the module <main_module> has mmloc = '8'
+    And analizo must report that the module <main_module> has nom = 1
+    And analizo must report that the module <main_module> has npm = 1
+    And analizo must report that the module <main_module> has rfc = 2
+    And analizo must report that the module <main_module> has sc = 1
     Examples:
-      | language | main_enum_module        | enum_module |
-      | java     | Main::MyEnumeration     | Enumeration |
+      | language | main_module |
+      | java     | Main        |
+
+  Scenario: "Enumeration" project, Main::MyEnumeration module metrics
+    Given I am in t/samples/enumeration/<language>
+    When I run "analizo metrics ."
+    Then analizo must report that the module <main_enum_module> has acc = 1
+    And analizo must report that the module <main_enum_module> has noa = 4
+    And analizo must report that the module <main_enum_module> has npa = 4
+    Examples:
+      | language | main_enum_module    |
+      | java     | Main::MyEnumeration |
+
+  Scenario: "Enumeration" project, Enumeration module metrics
+    Given I am in t/samples/enumeration/<language>
+    When I run "analizo metrics ."
+    And analizo must report that the module <enum_module> has noa = 4
+    And analizo must report that the module <enum_module> has npa = 4
+    Examples:
+      | language | enum_module |
+      | java     | Enumeration |

--- a/t/samples/enumeration/java/Enumeration.java
+++ b/t/samples/enumeration/java/Enumeration.java
@@ -1,0 +1,4 @@
+
+public enum Enumeration {
+	ONE, TWO, THREE, FOUR
+}

--- a/t/samples/enumeration/java/Main.java
+++ b/t/samples/enumeration/java/Main.java
@@ -1,0 +1,18 @@
+
+public class Main {
+
+	enum MyEnumeration {
+		A, B, C, D
+	}
+	
+
+	public static void main(String[] args) {
+		MyEnumeration enumeration = MyEnumeration.A;
+		
+		if(enumeration.equals(MyEnumeration.A))
+		{
+			System.out.println("Hello, World!");
+		}
+	}
+
+}


### PR DESCRIPTION
fixes #5

As discussed in #5, I created some Cucumber tests to ensure that analizo will always be a able to recognize classes that use enumeration, correctly analyze them and identify their modules.