### PR TITLE
Fixing ACC performance

### DIFF
--- a/lib/Analizo/Batch/Job.pm
+++ b/lib/Analizo/Batch/Job.pm
@@ -141,6 +141,7 @@ sub execute {
       $self->share_filters_with($extractor);
       $extractor->process('.');
     }
+    $model->graph;
     $self->cache->set($model_cache_key, $model);
   }
   $self->model($model);

--- a/lib/Analizo/Batch/Job.pm
+++ b/lib/Analizo/Batch/Job.pm
@@ -141,7 +141,7 @@ sub execute {
       $self->share_filters_with($extractor);
       $extractor->process('.');
     }
-    $model->graph;
+    $model->build_references_graphs;
     $self->cache->set($model_cache_key, $model);
   }
   $self->model($model);

--- a/lib/Analizo/GlobalMetric/ChangeCost.pm
+++ b/lib/Analizo/GlobalMetric/ChangeCost.pm
@@ -46,7 +46,7 @@ sub description {
 
 sub calculate {
   my ($self) = @_;
-  my $reachability_matrix = $self->model->graph->transitive_closure_matrix;
+  my $reachability_matrix = $self->model->get_files_graph->transitive_closure_matrix;
   my @vertices = sort $reachability_matrix->vertices;
   my $rows = scalar @vertices;
   return unless $rows;

--- a/lib/Analizo/Metric/AfferentConnections.pm
+++ b/lib/Analizo/Metric/AfferentConnections.pm
@@ -50,7 +50,7 @@ sub calculate {
 
   $self->analized_module($module);
 
-  my $acc_result = $self->model->graph->in_degree($module);
+  my $acc_result = $self->model->get_modules_graph->in_degree($module);
 
   return $acc_result ? $acc_result : 0;
 }

--- a/lib/Analizo/Metric/AfferentConnections.pm
+++ b/lib/Analizo/Metric/AfferentConnections.pm
@@ -47,69 +47,12 @@ sub description {
 
 sub calculate {
   my ($self, $module) = @_;
+
   $self->analized_module($module);
 
-  my $number_of_caller_modules = $self->_number_of_modules_that_call_module();
-  my $number_of_modules_on_inheritance_tree = $self->_recursive_number_of_children($self->analized_module);
+  my $acc_result = $self->model->graph->in_degree($module);
 
-  return $number_of_caller_modules + $number_of_modules_on_inheritance_tree;
-}
-
-sub _number_of_modules_that_call_module {
-  my ($self) = @_;
-
-  my @seen_modules = ();
-  for my $caller_member (keys(%{$self->model->calls})){
-    $self->_push_member_module_if_it_calls_analized_module($caller_member, \@seen_modules);
-  }
-
-  return scalar @seen_modules;
-}
-
-sub _push_member_module_if_it_calls_analized_module {
-  my ($self, $caller_member, $seen_modules) = @_;
-
-  my $caller_module = $self->model->members->{$caller_member};
-  if($self->_member_calls_analized_module($caller_member, $caller_module)){
-    push @{$seen_modules}, $caller_module;
-  }
-}
-
-sub _member_calls_analized_module {
-  my ($self, $caller_member, $caller_module) = @_;
-
-  for my $called_member (keys(%{$self->model->calls->{$caller_member}})) {
-    my $called_module = $self->model->members->{$called_member};
-    if($self->_called_module_is_the_analized($called_module, $caller_module)) {
-        return 1;
-    }
-  }
-  return 0;
-}
-
-sub _called_module_is_the_analized {
-  my ($self, $called_module, $caller_module) = @_;
-  return ($caller_module && $called_module) && $caller_module ne $called_module && $called_module eq $self->analized_module;
-}
-
-sub _recursive_number_of_children {
-  my ($self, $module) = @_;
-
-  my $number_of_children = 0;
-
-  for my $other_module ($self->model->module_names){
-    if ($self->_module_parent_of_other($module, $other_module)) {
-      $number_of_children += $self->_recursive_number_of_children($other_module) + 1;
-    }
-  }
-
-  return $number_of_children;
-}
-
-sub _module_parent_of_other {
-  my ($self, $module, $other_module) = @_;
-  return grep {$_ eq $module} $self->model->inheritance($other_module);
+  return $acc_result ? $acc_result : 0;
 }
 
 1;
-

--- a/lib/Analizo/Model.pm
+++ b/lib/Analizo/Model.pm
@@ -198,12 +198,12 @@ sub graph {
     $graph->add_vertex($module);
   }
   foreach my $caller (keys %{$self->calls}) {
-    my $calling_module = $self->_function_to_module($caller);
-    next unless (defined($calling_module));
+    next unless exists $self->members->{$caller};
+    my $calling_module = $self->members->{$caller};
     $graph->add_vertex($calling_module);
     foreach my $callee (keys %{$self->calls->{$caller}}) {
-      my $called_module = $self->_function_to_module($callee);
-      next unless (defined($called_module));
+      next unless exists $self->members->{$callee};
+      my $called_module = $self->members->{$callee};
       $graph->add_vertex($called_module);
       next if ($calling_module eq $called_module);
       $graph->add_edge($calling_module, $called_module);
@@ -215,12 +215,12 @@ sub graph {
       $self->_recursive_children($subclass, $superclass, $graph);
     }
   }
+  $self->{graph} = $graph;
   $graph;
 }
 
 sub _recursive_children {
   my ($self, $subclass, $superclass, $graph) = @_;
-
   $graph->add_edge($subclass, $superclass);
 
   foreach my $super_uper_class ($self->inheritance($superclass)) {

--- a/t/Analizo/Metric/AfferentConnections/AfferentConnectionsByInheritance.t
+++ b/t/Analizo/Metric/AfferentConnections/AfferentConnectionsByInheritance.t
@@ -15,6 +15,12 @@ use vars qw($model $acc);
 sub setup : Test(setup) {
   $model = Analizo::Model->new;
   $acc = Analizo::Metric::AfferentConnections->new(model => $model);
+
+  $model->declare_module('Mother', 'Mother.c');
+  $model->declare_module('Child1', 'Child1.c');
+  $model->declare_module('Child2', 'Child2.c');
+  $model->declare_module('Grandchild1', 'Grandchild1.c');
+  $model->declare_module('Grandchild2', 'Grandchild2.c');
 }
 
 sub use_package : Tests {
@@ -29,67 +35,37 @@ sub description : Tests {
   is($acc->description, 'Afferent Connections per Class (used to calculate COF - Coupling Factor)');
 }
 
-sub calculate : Tests {
-  $model->declare_module('A', 'A.c');
-  $model->declare_function('A', 'fA');
-  $model->declare_function('A', 'fA2');
-
-  $model->declare_module('B', 'B.c');
-  $model->declare_function('B', 'fB');
-  $model->declare_variable('B', 'vB');
-
-  $model->declare_module('C', 'C.c');
-  $model->declare_function('C', 'fC');
-  $model->declare_variable('C', 'vC');
-
-  is($acc->calculate('A'), 0, 'no acc module A');
-  is($acc->calculate('B'), 0, 'no acc module B');
-  is($acc->calculate('C'), 0, 'no acc module C');
-
-  $model->add_call('fA', 'fB');
-  is($acc->calculate('A'), 0, 'no calls to a module');
-  is($acc->calculate('B'), 1, 'calling function of another module');
-
-  $model->add_variable_use('fA', 'vB');
-  is($acc->calculate('A'), 0, 'no calls to a module');
-  is($acc->calculate('B'), 1, 'calling variable of another module');
-
-  $model->add_call('fA', 'fC');
-  is($acc->calculate('A'), 0, 'no calls to a module');
-  is($acc->calculate('C'), 1, 'calling variable of another module');
-
-  $model->add_call('fA', 'fA2');
-  is($acc->calculate('A'), 0, 'calling itself does not count as acc');
-
-  $model->add_variable_use('fB', 'vC');
-  is($acc->calculate('C'), 2, 'calling module twice');
-}
-
-sub calculate_with_inheritance : Tests {
-  $model->declare_module('Mother', 'Mother.c');
-  $model->declare_module('Child1', 'Child1.c');
-  $model->declare_module('Child2', 'Child2.c');
-  $model->declare_module('Grandchild1', 'Grandchild1.c');
-  $model->declare_module('Grandchild2', 'Grandchild2.c');
-
+sub calculate_first_degree_inheritance : Tests {
   $model->add_inheritance('Child1', 'Mother');
   is($acc->calculate('Mother'), 1, 'inheritance counts as acc to superclass');
   is($acc->calculate('Child1'), 0, 'inheritance does not count as acc to child');
+}
 
+sub calculate_multiple_childs : Tests {
+  $model->add_inheritance('Child1', 'Mother');
   $model->add_inheritance('Child2', 'Mother');
   is($acc->calculate('Mother'), 2, 'multiple inheritance counts as acc');
   is($acc->calculate('Child2'), 0, 'inheritance does not count as acc to another child');
+}
 
+sub calculate_deeper_tree : Tests {
+  $model->add_inheritance('Child1', 'Mother');
+  $model->add_inheritance('Child2', 'Mother');
   $model->add_inheritance('Grandchild1', 'Child1');
   is($acc->calculate('Grandchild1'), 0, 'grandchilds acc is not affected');
   is($acc->calculate('Child1'), 1, 'grandchild extending a child counts');
   is($acc->calculate('Mother'), 3, 'the deeper the tree, the biggest acc');
+}
 
+sub calculate_deeper_tree_new_grandchild : Tests {
+  $model->add_inheritance('Child1', 'Mother');
+  $model->add_inheritance('Child2', 'Mother');
+  $model->add_inheritance('Grandchild1', 'Child1');
   $model->add_inheritance('Grandchild2', 'Child2');
+
   is($acc->calculate('Grandchild2'), 0, 'grandchilds acc is not affected');
   is($acc->calculate('Child2'), 1, 'grandchild extending a child counts');
   is($acc->calculate('Mother'), 4, 'the deeper the tree, the biggest acc');
 }
 
 __PACKAGE__->runtests;
-

--- a/t/Analizo/Metric/AfferentConnections/AfferentConnectionsByReference.t
+++ b/t/Analizo/Metric/AfferentConnections/AfferentConnectionsByReference.t
@@ -1,0 +1,84 @@
+package t::Analizo::Metric::AfferentConnections;
+use strict;
+use warnings;
+use parent qw(Test::Analizo::Class);
+use Test::More;
+use File::Basename;
+
+use Analizo::Model;
+use Analizo::Metric::AfferentConnections;
+
+eval('$Analizo::Metric::QUIET = 1;'); # the eval is to avoid Test::* complaining about possible typo
+
+use vars qw($model $acc);
+
+sub setup : Test(setup) {
+  $model = Analizo::Model->new;
+  $acc = Analizo::Metric::AfferentConnections->new(model => $model);
+
+  $model->declare_module('A', 'A.c');
+  $model->declare_function('A', 'fA');
+  $model->declare_function('A', 'fA2');
+
+  $model->declare_module('B', 'B.c');
+  $model->declare_function('B', 'fB');
+  $model->declare_variable('B', 'vB');
+
+  $model->declare_module('C', 'C.c');
+  $model->declare_function('C', 'fC');
+  $model->declare_variable('C', 'vC');
+}
+
+sub use_package : Tests {
+  use_ok('Analizo::Metric::AfferentConnections');
+}
+
+sub has_model : Tests {
+  is($acc->model, $model);
+}
+
+sub description : Tests {
+  is($acc->description, 'Afferent Connections per Class (used to calculate COF - Coupling Factor)');
+}
+
+sub calculate_calling_function_of_another_module : Tests {
+  $model->add_call('fA', 'fB');
+  is($acc->calculate('A'), 0, 'no calls to a module');
+  is($acc->calculate('B'), 1, 'calling function of another module');
+}
+
+sub calculate_adding_variable_of_another_module : Tests {
+  $model->add_call('fA', 'fB');
+  $model->add_variable_use('fA', 'vB');
+  is($acc->calculate('A'), 0, 'no calls to a module');
+  is($acc->calculate('B'), 1, 'adding variable of another module');
+}
+
+sub calculate_calling_variable_of_another_module : Tests {
+  $model->add_call('fA', 'fC');
+  is($acc->calculate('A'), 0, 'no calls to a module');
+  is($acc->calculate('C'), 1, 'calling variable of another module');
+}
+
+sub calculate_calling_itself_does_not_count : Tests {
+  $model->add_call('fA', 'fA2');
+  is($acc->calculate('A'), 0, 'calling itself does not count as acc');
+}
+
+sub calculate_calling_module_twice : Tests {
+  $model->add_call('fA', 'fB');
+  $model->add_variable_use('fA', 'vB');
+  $model->add_call('fA', 'fC');
+  $model->add_call('fA', 'fA2');
+  $model->add_variable_use('fB', 'vC');
+  is($acc->calculate('C'), 2, 'calling module twice');
+}
+
+sub calculate_empty_acc : Tests {
+  is($acc->calculate('A'), 0, 'no acc module A');
+  is($acc->calculate('B'), 0, 'no acc module B');
+  is($acc->calculate('C'), 0, 'no acc module C');
+}
+
+__PACKAGE__->runtests;
+

--- a/t/Analizo/Metric/AfferentConnections/AfferentConnectionsComplete.t
+++ b/t/Analizo/Metric/AfferentConnections/AfferentConnectionsComplete.t
@@ -1,0 +1,57 @@
+package t::Analizo::Metric::AfferentConnections;
+use strict;
+use warnings;
+use parent qw(Test::Analizo::Class);
+use Test::More;
+use File::Basename;
+
+use Analizo::Model;
+use Analizo::Metric::AfferentConnections;
+
+eval('$Analizo::Metric::QUIET = 1;'); # the eval is to avoid Test::* complaining about possible typo
+
+use vars qw($model $acc);
+
+sub setup : Test(setup) {
+  $model = Analizo::Model->new;
+  $acc = Analizo::Metric::AfferentConnections->new(model => $model);
+
+  $model->declare_module('Friend', 'Friend.c');
+  $model->declare_module('Child', 'Child.c');
+  $model->declare_module('Mother', 'Mother.c');
+  $model->declare_module('MotherSister', 'MotherSister.c');
+  $model->declare_module('GrandMother', 'GrandMother.c');
+
+  $model->declare_function('Friend', 'friendTalk');
+  $model->declare_function('Child', 'childListen');
+  $model->declare_function('GrandMother', 'grandMotherListen');
+
+  $model->add_call('friendTalk', 'childListen');
+  $model->add_call('friendTalk', 'grandMotherListen');
+
+  $model->add_inheritance('Child', 'Mother');
+  $model->add_inheritance('Mother', 'GrandMother');
+  $model->add_inheritance('MotherSister', 'GrandMother');
+}
+
+sub use_package : Tests {
+  use_ok('Analizo::Metric::AfferentConnections');
+}
+
+sub has_model : Tests {
+  is($acc->model, $model);
+}
+
+sub description : Tests {
+  is($acc->description, 'Afferent Connections per Class (used to calculate COF - Coupling Factor)');
+}
+
+sub calculate_inheritance_and_references : Tests {
+  is($acc->calculate('GrandMother'), 4, 'deeper inheritance and reference counts as acc');
+  is($acc->calculate('Child'), 1, 'calls counts as acc to child');
+  is($acc->calculate('Mother'), 1, 'inheritance counts as acc to mother');
+  is($acc->calculate('MotherSister'), 0, 'have no inheritance neither calls to mother sister');
+  is($acc->calculate('Friend'), 0, 'have no inheritance neither calls to friend');
+}
+
+__PACKAGE__->runtests;

--- a/t/Analizo/Model.t
+++ b/t/Analizo/Model.t
@@ -177,10 +177,12 @@ sub build_graph_from_inheritance : Tests {
   $model->declare_module('a', 'src/a.c');
   $model->declare_module('b', 'src/b.c');
   $model->declare_module('c', 'src/c.c');
+  $model->declare_module('d', 'src/d.c');
   $model->add_inheritance('a', 'b');
   $model->add_inheritance('a', 'c');
+  $model->add_inheritance('c', 'd');
   my $g = $model->graph;
-  is("$g", 'a-b,a-c');
+  is("$g", 'a-b,a-c,a-d,c-d');
 }
 
 sub build_graph_from_funcion_calls_and_inheritance : Tests {
@@ -189,14 +191,16 @@ sub build_graph_from_funcion_calls_and_inheritance : Tests {
   $model->declare_module('b', 'src/b.c');
   $model->declare_module('c', 'src/c.c');
   $model->declare_module('d', 'src/d.c');
+  $model->declare_module('e', 'src/e.c');
   $model->add_inheritance('b', 'd');
+  $model->add_inheritance('d', 'e');
   $model->declare_function('a', 'a::name()');
   $model->declare_function('b', 'b::name()');
   $model->declare_function('c', 'c::name()');
   $model->add_call('a::name()', 'b::name()');
   $model->add_call('a::name()', 'c::name()');
   my $g = $model->graph;
-  is("$g", 'a-b,a-c,b-d');
+  is("$g", 'a-b,a-c,b-d,b-e,d-e');
 }
 
 sub use_file_as_vertices_in_graph : Tests {

--- a/t/Analizo/Model.t
+++ b/t/Analizo/Model.t
@@ -158,7 +158,7 @@ sub adding_abstract_class : Tests {
   is($model->abstract_classes, 1, 'model detects an abstract class');
 }
 
-sub build_graph_from_function_calls : Tests {
+sub build_graphs_from_function_calls : Tests {
   my $model = Analizo::Model->new;
   $model->declare_module('a', 'src/a.c');
   $model->declare_module('b', 'src/b.c');
@@ -168,11 +168,13 @@ sub build_graph_from_function_calls : Tests {
   $model->declare_function('c', 'c::name()');
   $model->add_call('a::name()', 'b::name()');
   $model->add_call('a::name()', 'c::name()');
-  my $g = $model->graph;
-  is("$g", 'a-b,a-c');
+  my $graph_modules = $model->get_modules_graph;
+  my $graph_files = $model->get_files_graph;
+  is("$graph_modules", 'a-b,a-c');
+  is("$graph_files", 'src/a-src/b,src/a-src/c');
 }
 
-sub build_graph_from_inheritance : Tests {
+sub build_graphs_from_inheritance : Tests {
   my $model = Analizo::Model->new;
   $model->declare_module('a', 'src/a.c');
   $model->declare_module('b', 'src/b.c');
@@ -181,11 +183,13 @@ sub build_graph_from_inheritance : Tests {
   $model->add_inheritance('a', 'b');
   $model->add_inheritance('a', 'c');
   $model->add_inheritance('c', 'd');
-  my $g = $model->graph;
-  is("$g", 'a-b,a-c,a-d,c-d');
+  my $graph_modules = $model->get_modules_graph;
+  my $graph_files = $model->get_files_graph;
+  is("$graph_modules", 'a-b,a-c,a-d,c-d');
+  is("$graph_files", 'src/a-src/b,src/a-src/c,src/a-src/d,src/c-src/d');
 }
 
-sub build_graph_from_funcion_calls_and_inheritance : Tests {
+sub build_graphs_from_funcion_calls_and_inheritance : Tests {
   my $model = Analizo::Model->new;
   $model->declare_module('a', 'src/a.c');
   $model->declare_module('b', 'src/b.c');
@@ -199,20 +203,24 @@ sub build_graph_from_funcion_calls_and_inheritance : Tests {
   $model->declare_function('c', 'c::name()');
   $model->add_call('a::name()', 'b::name()');
   $model->add_call('a::name()', 'c::name()');
-  my $g = $model->graph;
-  is("$g", 'a-b,a-c,b-d,b-e,d-e');
+  my $graph_modules = $model->get_modules_graph;
+  my $graph_files = $model->get_files_graph;
+  is("$graph_modules", 'a-b,a-c,b-d,b-e,d-e');
+  is("$graph_files", 'src/a-src/b,src/a-src/c,src/b-src/d,src/b-src/e,src/d-src/e');
 }
 
-sub use_file_as_vertices_in_graph : Tests {
+sub use_file_as_vertices_in_graphs : Tests {
   my $model = Analizo::Model->new;
   $model->declare_module('a', 'src/a.c');
   $model->declare_module('b', 'src/b.c');
   $model->declare_module('c', 'src/c.c');
-  my @vertices = sort $model->graph->vertices;
-  is_deeply(\@vertices, ['a', 'b', 'c']);
+  my @modules_vertices = sort $model->get_modules_graph->vertices;
+  my @files_vertices = sort $model->get_files_graph->vertices;
+  is_deeply(\@modules_vertices, ['a', 'b', 'c']);
+  is_deeply(\@files_vertices, ['src/a', 'src/b', 'src/c']);
 }
 
-sub group_files_when_build_graph : Tests {
+sub group_files_when_build_graphs : Tests {
   my $model = Analizo::Model->new;
   $model->declare_module('a', 'src/a.h');
   $model->declare_module('a', 'src/a.c');
@@ -220,8 +228,10 @@ sub group_files_when_build_graph : Tests {
   $model->declare_module('b', 'src/b.c');
   $model->declare_module('c', 'src/c.c');
   $model->declare_module('c', 'src/c.h');
-  my @vertices = sort $model->graph->vertices;
-  is_deeply(\@vertices, ['a', 'b', 'c']);
+  my @modules_vertices = sort $model->get_modules_graph->vertices;
+  my @files_vertices = sort $model->get_files_graph->vertices;
+  is_deeply(\@modules_vertices, ['a', 'b', 'c']);
+  is_deeply(\@files_vertices, ['src/a', 'src/b', 'src/c']);
 }
 
 sub empty_call_graph : Tests {

--- a/t/Analizo/Model.t
+++ b/t/Analizo/Model.t
@@ -169,7 +169,7 @@ sub build_graph_from_function_calls : Tests {
   $model->add_call('a::name()', 'b::name()');
   $model->add_call('a::name()', 'c::name()');
   my $g = $model->graph;
-  is("$g", 'src/a-src/b,src/a-src/c');
+  is("$g", 'a-b,a-c');
 }
 
 sub build_graph_from_inheritance : Tests {
@@ -180,7 +180,7 @@ sub build_graph_from_inheritance : Tests {
   $model->add_inheritance('a', 'b');
   $model->add_inheritance('a', 'c');
   my $g = $model->graph;
-  is("$g", 'src/a-src/b,src/a-src/c');
+  is("$g", 'a-b,a-c');
 }
 
 sub build_graph_from_funcion_calls_and_inheritance : Tests {
@@ -196,7 +196,7 @@ sub build_graph_from_funcion_calls_and_inheritance : Tests {
   $model->add_call('a::name()', 'b::name()');
   $model->add_call('a::name()', 'c::name()');
   my $g = $model->graph;
-  is("$g", 'src/a-src/b,src/a-src/c,src/b-src/d');
+  is("$g", 'a-b,a-c,b-d');
 }
 
 sub use_file_as_vertices_in_graph : Tests {
@@ -205,7 +205,7 @@ sub use_file_as_vertices_in_graph : Tests {
   $model->declare_module('b', 'src/b.c');
   $model->declare_module('c', 'src/c.c');
   my @vertices = sort $model->graph->vertices;
-  is_deeply(\@vertices, ['src/a', 'src/b', 'src/c']);
+  is_deeply(\@vertices, ['a', 'b', 'c']);
 }
 
 sub group_files_when_build_graph : Tests {
@@ -217,7 +217,7 @@ sub group_files_when_build_graph : Tests {
   $model->declare_module('c', 'src/c.c');
   $model->declare_module('c', 'src/c.h');
   my @vertices = sort $model->graph->vertices;
-  is_deeply(\@vertices, ['src/a', 'src/b', 'src/c']);
+  is_deeply(\@vertices, ['a', 'b', 'c']);
 }
 
 sub empty_call_graph : Tests {

--- a/t/features/metrics/deep_inheritance_afferent_connections.feature
+++ b/t/features/metrics/deep_inheritance_afferent_connections.feature
@@ -1,0 +1,21 @@
+Feature: afferent connections with deep inheritance
+  As a software developer
+  I want analizo to report the afferent connections of each module
+  So that I can evaluate it
+
+  Scenario: afferent connections of the dog family java sample
+    Given I am in t/samples/deep_inheritance/java
+    When I run "analizo metrics ."
+    Then analizo must report that module <module> has acc = <acc>
+    Examples:
+      | module                      | acc  |
+      | Dog                         | 8    |
+      | DogFirstGreatGrandson       | 1    |
+      | DogFirstPuppy               | 4    |
+      | DogGrandson                 | 3    |
+      | DogSecondGreatGrandson      | 0    |
+      | DogSecondPuppy              | 0    |
+      | DogSuperYoung               | 0    |
+      | Human                       | 2    |
+      | ShopController              | 0    |
+      | VenderShop                  | 1    |

--- a/t/samples/deep_inheritance/java/Dog.java
+++ b/t/samples/deep_inheritance/java/Dog.java
@@ -1,0 +1,8 @@
+class Dog {
+    String name;
+    Human owner;
+
+    public Human getOwner(){
+        return owner;
+    }
+}

--- a/t/samples/deep_inheritance/java/DogFirstGreatGrandson.java
+++ b/t/samples/deep_inheritance/java/DogFirstGreatGrandson.java
@@ -1,0 +1,3 @@
+class DogFirstGreatGrandson extends DogGrandson {
+    String noses;
+}

--- a/t/samples/deep_inheritance/java/DogFirstPuppy.java
+++ b/t/samples/deep_inheritance/java/DogFirstPuppy.java
@@ -1,0 +1,3 @@
+class DogFirstPuppy extends Dog {
+    String color;
+}

--- a/t/samples/deep_inheritance/java/DogGrandson.java
+++ b/t/samples/deep_inheritance/java/DogGrandson.java
@@ -1,0 +1,3 @@
+class DogGrandson extends DogFirstPuppy {
+    String number_of_eyes;
+}

--- a/t/samples/deep_inheritance/java/DogSecondGreatGrandson.java
+++ b/t/samples/deep_inheritance/java/DogSecondGreatGrandson.java
@@ -1,0 +1,3 @@
+class DogSecondGreatGrandson extends DogGrandson {
+    String arms;
+}

--- a/t/samples/deep_inheritance/java/DogSecondPuppy.java
+++ b/t/samples/deep_inheritance/java/DogSecondPuppy.java
@@ -1,0 +1,3 @@
+class DogSecondPuppy extends Dog {
+    String age;
+}

--- a/t/samples/deep_inheritance/java/DogSuperYoung.java
+++ b/t/samples/deep_inheritance/java/DogSuperYoung.java
@@ -1,0 +1,3 @@
+class DogSuperYoung extends DogFirstGreatGrandson {
+    String accs;
+}

--- a/t/samples/deep_inheritance/java/Human.java
+++ b/t/samples/deep_inheritance/java/Human.java
@@ -1,0 +1,8 @@
+class Human {
+    String name;
+    Dog pet;
+
+    public Dog getPetName(){
+        return pet.name;
+    }
+}

--- a/t/samples/deep_inheritance/java/ShopController.java
+++ b/t/samples/deep_inheritance/java/ShopController.java
@@ -1,0 +1,10 @@
+class ShopController {
+
+    public void main(){
+        Human owner = new Human();
+        owner.name = "Robson";
+
+        VenderShop vender = new VenderShop();
+        vender.sellDogTo(owner);
+    }
+}

--- a/t/samples/deep_inheritance/java/VenderShop.java
+++ b/t/samples/deep_inheritance/java/VenderShop.java
@@ -1,0 +1,10 @@
+class VenderShop {
+
+    public void sellDogTo(Human owner){
+        Dog dog = new Dog();
+        dog.name = "Toby";
+        dog.owner = owner;
+
+        owner.pet = dog;
+    }
+}


### PR DESCRIPTION
This pull request fixes #127 .

The details of the implementations can be found in the commits comments.

* Before improvement:
   * Total execution time was **236** seconds, executing **446,630,977** statements and **56,380,413** subroutine calls in the master branch;
   * Analyze :: Metric :: AfferentConnections :: calculate = **56.67%** of the total execution, executing **56,965,358** statements in **72.2 seconds**.

* After improvement:
   * Total execution time was **50.5** seconds, executing **178.168.102** statements and **6,510,898** subroutine calls after the modifications in this branh; 
   * Analyze :: Metric :: AfferentConnections :: calculate = **0.19%** of the total execution, executing **4,953** statements in **6.88 milliseconds**.

This information was obtained through the **nytprof** program.