### PR TITLE
Fix nom metric calculation for C code

### DIFF
--- a/lib/Analizo/Extractor/Doxyparse.pm
+++ b/lib/Analizo/Extractor/Doxyparse.pm
@@ -96,7 +96,7 @@ sub feed {
         elsif ($type eq 'variable') {
           $self->model->declare_variable($self->current_module, $qualified_name);
         }
-
+        # macro declarations
         elsif ($type eq 'macro definition') {
           $self->model->declare_macro($self->current_module, $qualified_name);
         }

--- a/lib/Analizo/Extractor/Doxyparse.pm
+++ b/lib/Analizo/Extractor/Doxyparse.pm
@@ -87,7 +87,7 @@ sub feed {
         my $type = $definition->{$name}->{type};
         my $qualified_name = _qualified_name($self->current_module, $name);
         $self->{current_member} = $qualified_name;
-
+        
         # function declarations
         if ($type eq 'function') {
           $self->model->declare_function($self->current_module, $qualified_name);
@@ -96,10 +96,9 @@ sub feed {
         elsif ($type eq 'variable') {
           $self->model->declare_variable($self->current_module, $qualified_name);
         }
-        #FIXME: Implement define treatment (no novo doxyparse identifica como type = "macro definition")
-        # define declarations
+
         elsif ($type eq 'macro definition') {
-          #$self->{current_member} = $qualified_name;
+          $self->model->declare_macro($self->current_module, $qualified_name);
         }
 
         # public members

--- a/lib/Analizo/Model.pm
+++ b/lib/Analizo/Model.pm
@@ -186,33 +186,46 @@ sub macros {
 
 sub functions {
   my ($self, $module) = @_;
-  my $list = $self->{modules}->{$module}->{functions};
-  my $macro_list = $self->{modules}->{$module}->{macros};
-  my @new_func_list = [];
-  
-  # filter which functions are macros instead
-  foreach ( @{$list} ) {
-    my $e1 = $_;
 
-    # remove brackets for comparison
-    $e1 =~ s/\(//;
-    $e1 =~ s/\)//;
+  my $function_list = $self->{modules}->{$module}->{functions};
+  my @macro_list = ();
+  my @new_func_list = ();
 
-    my $contains = 0;
-    
-    foreach ( @{$macro_list} ) {
-        if($e1 eq $_){
-            $contains = 1;
-            last;
-        }
-    }
-
-    if($contains == 0){
-        push(@new_func_list, $e1);
+  foreach my $key (keys %{$self->{modules}}){
+    foreach(@{$self->{modules}->{$key}->{macros}}){
+      push(@macro_list, $_);
     }
   }
 
-  return @new_func_list
+  # filter which functions are macros instead
+  foreach ( @{$function_list} ) {
+    my $function = $_;
+
+    # remove brackets for comparison
+    $function =~ s/\(//;
+    $function =~ s/\)//;
+
+    #remove module reference
+    my (undef, $func_name) = split('::\s*', $function);
+
+    my $contains = 0;
+    
+    foreach ( @macro_list ) {
+      #remove module reference
+      my (undef, $macro_name) = split('::\s*', $_);
+      
+      if($func_name eq $macro_name){
+          $contains = 1;
+          last;
+      }
+    }
+
+    if($contains == 0){
+      push(@new_func_list, $function);
+    }
+  }
+
+  return @new_func_list;
 }
 
 sub variables {

--- a/lib/Analizo/Model.pm
+++ b/lib/Analizo/Model.pm
@@ -185,7 +185,6 @@ sub macros {
 }
 
 sub functions {
-  #        FIX MACRO WITH PARAMETER
   my ($self, $module) = @_;
 
   my $function_list = $self->{modules}->{$module}->{functions};
@@ -203,11 +202,10 @@ sub functions {
     my $function = $_;
 
     # remove brackets for comparison
-    my ($function, undef) = split('\(', $function);
+    my ($raw_function, undef) = split('\(', $function);
 
     #remove module reference
-    my (undef, $func_name) = split('::\s*', $function);
-    print "function $func_name\n";
+    my (undef, $func_name) = split('::\s*', $raw_function);
 
     my $contains = 0;
     

--- a/lib/Analizo/Model.pm
+++ b/lib/Analizo/Model.pm
@@ -91,6 +91,19 @@ sub type {
   return $self->{types}->{$member};
 }
 
+sub declare_macro {
+  my ($self, $module, $macro) = @_;
+  $self->declare_member($module, $macro, 'macro');
+
+  if (!exists($self->{modules}->{$module})){
+    $self->{modules}->{$module} = {};
+    $self->{modules}->{$module}->{macros} = [];
+  }
+  if(! grep { $_ eq $macro } @{$self->{modules}->{$module}->{macros}}){
+    push @{$self->{modules}->{$module}->{macros}}, $macro;
+  }
+}
+
 sub declare_function {
   my ($self, $module, $function) = @_;
   return unless $module;
@@ -165,10 +178,41 @@ sub add_parameters {
   $self->{parameters}->{$function} = $parameters;
 }
 
+sub macros {
+  my ($self, $module) = @_;
+  my $list = $self->{modules}->{$module}->{macros};
+  return $list ? @$list : ();
+}
+
 sub functions {
   my ($self, $module) = @_;
   my $list = $self->{modules}->{$module}->{functions};
-  return $list ? @$list : ();
+  my $macro_list = $self->{modules}->{$module}->{macros};
+  my @new_func_list = [];
+  
+  # filter which functions are macros instead
+  foreach ( @{$list} ) {
+    my $e1 = $_;
+
+    # remove brackets for comparison
+    $e1 =~ s/\(//;
+    $e1 =~ s/\)//;
+
+    my $contains = 0;
+    
+    foreach ( @{$macro_list} ) {
+        if($e1 eq $_){
+            $contains = 1;
+            last;
+        }
+    }
+
+    if($contains == 0){
+        push(@new_func_list, $e1);
+    }
+  }
+
+  return @new_func_list
 }
 
 sub variables {

--- a/lib/Analizo/Model.pm
+++ b/lib/Analizo/Model.pm
@@ -185,6 +185,7 @@ sub macros {
 }
 
 sub functions {
+  #        FIX MACRO WITH PARAMETER
   my ($self, $module) = @_;
 
   my $function_list = $self->{modules}->{$module}->{functions};
@@ -202,11 +203,11 @@ sub functions {
     my $function = $_;
 
     # remove brackets for comparison
-    $function =~ s/\(//;
-    $function =~ s/\)//;
+    my ($function, undef) = split('\(', $function);
 
     #remove module reference
     my (undef, $func_name) = split('::\s*', $function);
+    print "function $func_name\n";
 
     my $contains = 0;
     


### PR DESCRIPTION
This PR partially resolves #154 by creating a macro definition list and when the functions list is requested we return only the functions that are not in list of macros. This works when the macro is defined in the analyzed code, but for macros from external libraries we can't infer if it's a macro, so we have to add some logic to doxyparse to catch this.