### PR TITLE
Ubuntu xenial install steps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,8 +4,8 @@ You have more than one choice of install, see below.
 
 ## Debian package
 
-Analizo is readily available as a Debian package. This package migth work with
-Ubuntu as well. Installing the Debian package has the follwing advantages:
+Analizo is readily available as a Debian package. This package might work with Ubuntu 18.04 or upper versions as well. For 16.04 version see this [section]().
+Installing the Debian package has the follwing advantages:
 
   1. you do not have to compile anything
   2. all dependencies are installed automatically for you
@@ -65,3 +65,37 @@ sudo make install
 
 See the HACKING.md file for instructions on how to install Analizo dependencies.
 You neeed to install the dependencies before installing Analizo from sources.
+
+
+## Running on Ubuntu 16.04
+
+As reported in this [issue](https://github.com/analizo/analizo/issues/149) Analizo __.deb__
+package had some problems during installation on Ubuntu xenial versions. This problem is caused by an incompatible version of perl, which on xenial release is 5.22 and analizo runs just over 5.24 versions. So, to workaround this follow those steps.
+
+1) Install [perlbrew](https://perlbrew.pl/). Perlbrew is a management tool to install diferent versions of perl without mixing out with your local enviroment. Install and check if the instalation was sucessufull:
+```console
+sudo apt install perlbrew
+perlbrew --version
+```
+
+2) Install a newest version of perl:
+```console
+perlbrew init
+perlbrew install perl-5.26.1
+perlbrew switch perl-5.26.1
+```
+
+3) This step will change you to an enviroment with the perl you just installed. Install [cpanminus](https://metacpan.org/pod/App::cpanminus):
+```console
+cpan App::cpanminus
+```
+
+4) It's important before you install Analizo that you have this following dependencies:
+```console
+sudo apt install libssl-dev libmagic-dev libzmq-dev libexpat1-dev gnuplot git
+```
+
+5) Then you can install Analizo
+```console
+cpanm Analizo
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ You have more than one choice of install, see below.
 
 ## Debian package
 
-Analizo is readily available as a Debian package. This package might work with Ubuntu 18.04 or upper versions as well. For 16.04 version see this [section]().
+Analizo is readily available as a Debian package. This package might work with Ubuntu 18.04 or upper versions as well. For 16.04 version see this [section](https://github.com/black-neck/analizo/blob/ubuntu_xenial_install/INSTALL.md#running-on-ubuntu-1604).
 Installing the Debian package has the follwing advantages:
 
   1. you do not have to compile anything

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,7 +70,7 @@ You neeed to install the dependencies before installing Analizo from sources.
 ## Running on Ubuntu 16.04
 
 As reported in this [issue](https://github.com/analizo/analizo/issues/149) Analizo __.deb__
-package had some problems during installation on Ubuntu xenial versions. This problem is caused by an incompatible version of perl, which on xenial release is 5.22 and analizo runs just over 5.24 versions. So, to workaround this follow those steps.
+package had some problems during installation on Ubuntu xenial versions. This problem is caused by an incompatible version of perl. So, to workaround this follow those steps.
 
 1) Install [perlbrew](https://perlbrew.pl/). Perlbrew is a management tool to install diferent versions of perl without mixing out with your local enviroment. Install and check if the instalation was sucessufull:
 ```console


### PR DESCRIPTION
Based on issue #149 I tested some ways to install Analizo using Ubuntu 16.04.
I found that the .deb package needs one lib (libzmq-ffi-perl) that's not available on xenial sources. The other way to install is using perlbrew and install newer version of perl.