### PR TITLE
ignore prototype functions to fix NOM metric

### DIFF
--- a/lib/Analizo/Extractor/Doxyparse.pm
+++ b/lib/Analizo/Extractor/Doxyparse.pm
@@ -84,6 +84,7 @@ sub feed {
 
       foreach my $definition (@{$yaml->{$full_filename}->{$module}->{defines}}) {
         my ($name) = keys %$definition;
+        next if $definition->{$name}->{prototype} and $definition->{$name}->{prototype} eq 'yes';
         my $type = $definition->{$name}->{type};
         my $qualified_name = _qualified_name($self->current_module, $name);
         $self->{current_member} = $qualified_name;

--- a/t/features/metrics/number_of_methods.feature
+++ b/t/features/metrics/number_of_methods.feature
@@ -23,3 +23,8 @@ Feature: number of methods
       | animals  | csharp   |  Animal    | 1    |
       | animals  | csharp   |  Cat       | 2    |
       | animals  | csharp   |  Dog       | 2    |
+
+  Scenario: not computes macro on C code as method definition
+    Given I am in t/samples/macro
+    When I run "analizo metrics ."
+    Then analizo must report that module using_macro has nom = 1

--- a/t/samples/macro/using_macro.c
+++ b/t/samples/macro/using_macro.c
@@ -1,0 +1,9 @@
+// https://github.com/analizo/analizo/issues/154
+
+#include <stdio.h>
+
+SOME_EXTERNAL_MACRO(1);
+
+int main(int argc, char **argv) {
+  printf("this program has just this one main() method");
+}

--- a/t/samples/macro/using_macro.h
+++ b/t/samples/macro/using_macro.h
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+SOME_EXTERNAL_MACRO(1);
+
+int main(int argc, char **argv);


### PR DESCRIPTION
Doxygen detects macros use as prototype declaration, as
analizo doesn't care about prototype at all and macros should
not be identified as function declaration, then I'l going
to ignore on the analizo side all function detected by Doxygen
as prototype, this depends on next Doxyparse 1.8.18+

closes #154